### PR TITLE
Simplified version needs AWS to be passed in for now

### DIFF
--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -1,28 +1,24 @@
 'use strict';
 
-const Promise = require('bluebird');
+const BPromise = require('bluebird');
 const AWS = require('aws-sdk');
 
 /**
+ * @param {object} AWS - config-ready AWS lib instance
+ * @param {object} config - optional document client config
+ * 
  * @example
- * const aws = require('@sparkpost/aws');
- * const ddbClient = new aws.DynamoDB(config).client;
+ * const AWS = require('aws-sdk');
+ * const ddbClient = new require('@sparkpost/aws').DynamoDB(AWS).client;
  *
  * ddbClient.getAsync(..etc).then(...etc);
  *
  */
 module.exports = class DynamoDB {
 
-  constructor(config) {
-    this.config = config;
+  constructor(AWS, config) {
     this.client = new AWS.DynamoDB.DocumentClient(config);
-    Promise.promisifyAll(this.client);
+    BPromise.promisifyAll(this.client);
   }
-
-  // getRawClient() {
-  //   const rawClient = new AWS.DynamoDB(config);
-  //   Promise.promisifyAll(rawClient);
-  //   return rawClient;
-  // }
 
 }


### PR DESCRIPTION
Option 1, super simple, ready to go right now but requires you to instantiate aws-sdk with your AWS credentials/region separately.