### PR TITLE
Takes aws config and creates connection first

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = {
+  baseAWS: require('aws-sdk'),
   DynamoDB: require('./lib/dynamo')
 };

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Promise = require('bluebird');
+const BPromise = require('bluebird');
 const AWS = require('aws-sdk');
 
 /**
@@ -14,15 +14,10 @@ const AWS = require('aws-sdk');
 module.exports = class DynamoDB {
 
   constructor(config) {
-    this.config = config;
-    this.client = new AWS.DynamoDB.DocumentClient(config);
-    Promise.promisifyAll(this.client);
+    config = config || {}
+    this.AWS = config.awsInstance || new AWS(config.aws);
+    this.client = new this.AWS.DynamoDB.DocumentClient(config.client);
+    BPromise.promisifyAll(this.client);
   }
-
-  // getRawClient() {
-  //   const rawClient = new AWS.DynamoDB(config);
-  //   Promise.promisifyAll(rawClient);
-  //   return rawClient;
-  // }
 
 }


### PR DESCRIPTION
A more complete way to handle AWS config, services only need to require this lib in and pass it the config like:
```
const aws = require('@sparkpost/aws')
const db = new aws.DynamoDB({ credentials, region }).client

db.getAsync().then()
```