### PR TITLE
FAD-5752: bypass the proxy for dynamo calls by default

### DIFF
--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird');
 const AWS = require('aws-sdk');
 const helpers = require('./dynamo-helpers');
+const _ = require('lodash');
 
 /**
  * @example
@@ -15,8 +16,18 @@ const helpers = require('./dynamo-helpers');
 module.exports = class DynamoDB {
 
   constructor(config) {
+    if (config == undefined) {
+      config = {};
+    }
     this.config = config;
+
+    if ( !('bypassProxy' in config) || config.bypassProxy == true) {
+      _.defaults(config, { 'httpOptions' : { 'agent': undefined } });
+      // in case it already had agent set
+      config.httpOptions.agent = undefined;
+    }
     this.client = new AWS.DynamoDB.DocumentClient(config);
+
     this.helpers = helpers;
     Promise.promisifyAll(this.client);
   }

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -16,13 +16,13 @@ const _ = require('lodash');
 module.exports = class DynamoDB {
 
   constructor(config) {
-    if (config == undefined) {
+    if (config === undefined) {
       config = {};
     }
     this.config = config;
 
-    if ( !('bypassProxy' in config) || config.bypassProxy == true) {
-      _.defaults(config, { 'httpOptions' : { 'agent': undefined } });
+    if (!('bypassProxy' in config) || config.bypassProxy === true) {
+      _.defaults(config, { 'httpOptions': { 'agent': undefined } });
       // in case it already had agent set
       config.httpOptions.agent = undefined;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/aws",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3615,11 +3615,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3646,6 +3641,11 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/test/unit/lib/dynamo.spec.js
+++ b/test/unit/lib/dynamo.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+
+chai.use(require('chai-sinon'));
+chai.use(require('chai-as-promised'));
+
+describe('Dynamo wrappper', function() {
+  let awsMock
+    , dynamo
+    , stub;
+
+  beforeEach(function() {
+    stub = sinon.stub();
+
+    awsMock = {
+      config: {
+        region: 'Winterfel'
+      },
+      DynamoDB: {
+        DocumentClient: class {
+          constructor(config) { console.log(stub); stub(config); }
+        }
+      }
+    };
+
+    dynamo = proxyquire('../../../lib/dynamo', {
+      'aws-sdk': awsMock
+    });
+  });
+
+  describe("Constructor", function() {
+    it("should override proxy settings", function() {
+      var d = new dynamo({ 'httpOptions': { 'agent': "proxy", 'otherSetting': "this should stay" }});
+      //console.log(stub);
+      expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined, otherSetting: "this should stay"} });
+    });
+  });
+});

--- a/test/unit/lib/dynamo.spec.js
+++ b/test/unit/lib/dynamo.spec.js
@@ -10,7 +10,7 @@ chai.use(require('chai-as-promised'));
 
 describe('Dynamo wrappper', function() {
   let awsMock
-    , dynamo
+    , Dynamo
     , stub;
 
   beforeEach(function() {
@@ -27,15 +27,15 @@ describe('Dynamo wrappper', function() {
       }
     };
 
-    dynamo = proxyquire('../../../lib/dynamo', {
+    Dynamo = proxyquire('../../../lib/dynamo', {
       'aws-sdk': awsMock
     });
   });
 
-  describe("Constructor", function() {
-    it("should override proxy settings", function() {
-      var d = new dynamo({ 'httpOptions': { 'agent': "proxy", 'otherSetting': "this should stay" }});
-      expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined, otherSetting: "this should stay"} });
+  describe('Constructor', function() {
+    it('should override proxy settings', function() {
+      new Dynamo({ 'httpOptions': { 'agent': 'proxy', 'otherSetting': 'this should stay' }});
+      expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined, otherSetting: 'this should stay'} });
     });
   });
 });

--- a/test/unit/lib/dynamo.spec.js
+++ b/test/unit/lib/dynamo.spec.js
@@ -22,7 +22,7 @@ describe('Dynamo wrappper', function() {
       },
       DynamoDB: {
         DocumentClient: class {
-          constructor(config) { console.log(stub); stub(config); }
+          constructor(config) { stub(config); }
         }
       }
     };
@@ -35,7 +35,6 @@ describe('Dynamo wrappper', function() {
   describe("Constructor", function() {
     it("should override proxy settings", function() {
       var d = new dynamo({ 'httpOptions': { 'agent': "proxy", 'otherSetting': "this should stay" }});
-      //console.log(stub);
       expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined, otherSetting: "this should stay"} });
     });
   });

--- a/test/unit/lib/dynamo.spec.js
+++ b/test/unit/lib/dynamo.spec.js
@@ -34,8 +34,18 @@ describe('Dynamo wrappper', function() {
 
   describe('Constructor', function() {
     it('should override proxy settings', function() {
-      new Dynamo({ 'httpOptions': { 'agent': 'proxy', 'otherSetting': 'this should stay' }});
+      new Dynamo({ httpOptions: { agent: 'proxy', otherSetting: 'this should stay' }});
       expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined, otherSetting: 'this should stay'} });
+    });
+
+    it('should create an empty config if no config passed', function() {
+      new Dynamo();
+      expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined} });
+    });
+
+    it('should retain proxy settings if config.bypassProxy is false', function() {
+      new Dynamo({ httpOptions: { agent: 'proxy' }, bypassProxy: false});
+      expect(stub).to.have.been.calledWith({ httpOptions: { agent: 'proxy' }, bypassProxy: false });
     });
   });
 });


### PR DESCRIPTION
Add an optional config value to our dynamo wrapper - `bypassProxy`
defaults to true.  Unset the proxy agent if it's unset or set
to true, this allows us to directly use VPC endpoints for
dynamo (but can still use the proxy if need be).