### PR TITLE
correctly use the default HTTP agent when bypass proxy is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const AWS = require('aws-sdk');
 const proxy = require('proxy-agent');
+var clientConfig = require('./lib/client-config');
 
 module.exports = {
   initialize: (conf) => {
@@ -17,7 +18,7 @@ module.exports = {
 
     configurationKeys.forEach((key) => {
       if (key === 'proxy' && conf.proxy) {
-        awsConf.httpOptions = { agent: proxy(conf.proxy) };
+        clientConfig.httpOptions = { agent: proxy(conf.proxy) }
       } else if (key in conf) {
         awsConf[key] = conf[key];
       }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const AWS = require('aws-sdk');
 const proxy = require('proxy-agent');
-var clientConfig = require('./lib/client-config');
+const clientConfig = require('./lib/client-config');
 
 module.exports = {
   initialize: (conf) => {
@@ -18,7 +18,7 @@ module.exports = {
 
     configurationKeys.forEach((key) => {
       if (key === 'proxy' && conf.proxy) {
-        clientConfig.httpOptions = { agent: proxy(conf.proxy) }
+        clientConfig.httpOptions = { agent: proxy(conf.proxy) };
       } else if (key in conf) {
         awsConf[key] = conf[key];
       }

--- a/lib/client-config.js
+++ b/lib/client-config.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -20,8 +20,8 @@ function createClient(config) {
   /*
    * by default try to connect to dynamo directly
    */
-  if (!('bypassProxy' in config) || config.bypassProxy === true) {
-    if ('httpOptions' in config && 'agent' in config.httpOptions) {
+  if (config.bypassProxy !== false) {
+    if ('httpOptions' in config) {
       /*
        * remove the proxy agent (from config if it's there).  the
        * distinction between removing the key and setting it to undefined

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird');
 const AWS = require('aws-sdk');
 const helpers = require('./dynamo-helpers');
 const _ = require('lodash');
+const clientConfig = require('./client-config');
 
 /**
  * Creates an AWS document client instance and decorates the instance
@@ -14,13 +15,22 @@ function createClient(config) {
   if (config === undefined) {
     config = {};
   }
+  config = _.merge(clientConfig, config);
 
+  /*
+   * by default try to connect to dynamo directly
+   */
   if (!('bypassProxy' in config) || config.bypassProxy === true) {
-    _.defaults(config, { 'httpOptions': { 'agent': undefined } });
-    // in case it already had agent set
-    config.httpOptions.agent = undefined;
+    if ('httpOptions' in config && 'agent' in config.httpOptions) {
+      /*
+       * remove the proxy agent (from config if it's there).  the
+       * distinction between removing the key and setting it to undefined
+       * is a big one, as AWS will simply not use connection pooling if
+       * it's set to undefined
+       */
+      delete config.httpOptions.agent;
+    }
   }
-
   const client = new AWS.DynamoDB.DocumentClient(config);
   client.consistentReads = config.consistentReads || false;
   Promise.promisifyAll(client);

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -15,7 +15,10 @@ function createClient(config) {
   if (config === undefined) {
     config = {};
   }
-  config = _.merge(clientConfig, config);
+  // copy b/c we want any dynamo specific flags to override
+  // what was set globally - but we don't want to clobber the global
+  // settings
+  config = _.merge(_.cloneDeep(clientConfig), config);
 
   /*
    * by default try to connect to dynamo directly

--- a/lib/sns.js
+++ b/lib/sns.js
@@ -2,9 +2,10 @@
 
 const AWS = require('aws-sdk');
 const Promise = require('bluebird');
+const clientConfig = require('./client-config');
 
 module.exports = function({ account, arnSuffix = '', defaultSubject = '' }) {
-  const SNS = new AWS.SNS();
+  const SNS = new AWS.SNS(clientConfig);
   const publish = Promise.promisify(SNS.publish, { context: SNS });
 
   function constructARN(name) {

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const AWS = require('aws-sdk');
 const Promise = require('bluebird');
+const clientConfig = require('./client-config');
 
 /**
  * Convenience class for wrapping sqs methods with promises
@@ -13,8 +14,7 @@ const Promise = require('bluebird');
  * @param defaultVisibilityTimeout A default visibility timeout used for retrieving messages, defaults to 300 secons
  */
 module.exports = ({ account, queuePrefix = '', queueSuffix = '', defaultVisibilityTimeout = 300 }) => {
-
-  const SQS = new AWS.SQS();
+  const SQS = new AWS.SQS(clientConfig);
   Promise.promisifyAll(SQS);
 
   function getQueueURL(name) {

--- a/test/unit/lib/dynamo.spec.js
+++ b/test/unit/lib/dynamo.spec.js
@@ -33,14 +33,15 @@ describe('Dynamo wrappper', function() {
   });
 
   describe('Constructor', function() {
+
     it('should override proxy settings', function() {
       new Dynamo({ httpOptions: { agent: 'proxy', otherSetting: 'this should stay' }});
-      expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined, otherSetting: 'this should stay'} });
+      expect(stub).to.have.been.calledWith({ httpOptions: {otherSetting: 'this should stay'} });
     });
 
     it('should create an empty config if no config passed', function() {
       new Dynamo();
-      expect(stub).to.have.been.calledWith({ httpOptions: {agent: undefined} });
+      expect(stub).to.have.been.calledWith({ });
     });
 
     it('should retain proxy settings if config.bypassProxy is false', function() {


### PR DESCRIPTION
passing { HttpOptions: { agent: undefined } } causes the AWS sdk
to not use a http agent at all, which is very undesirable (no
connection pooling).

Move the proxy configuration into a new singleton so that it can
be overriden on a lib by lib basis rather than in the global
AWS configuration.  And only pass the proxyAgent setting for dynamo
if it's explictly specified.