### PR TITLE
Adds new method for emitting page results to a provided callback

### DIFF
--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -65,6 +65,31 @@ function createClient(config) {
       });
   };
 
+  /**
+   * Works like queryAll but on each page of the query a callback is invoked.  Its expected that the callback returns a promise.
+   * This function will resolve when all paged callback promises(param pagePromise) resolve.
+   *
+   * @param params {Object} - Original query params
+   * @param pagePromise {Function} - A function that returns a promise
+   * @param promises {Array} - not intended to be passed, this collects promises for paging resolution
+   * @returns {*|PromiseLike<T>|Promise<T>}
+   */
+  client.queryAllPager = function queryAllRecordsPager(params, pagePromise, promises = []) {
+    return client.queryAsync(params)
+      .then((results) => {
+        results.Items = results.Items || [];
+
+        promises.push(pagePromise(results.Items));
+
+        if ('LastEvaluatedKey' in results) {
+          params.ExclusiveStartKey = results.LastEvaluatedKey;
+          return queryAllRecordsPager.apply(this, [params, pagePromise, promises]);
+        }
+
+        return Promise.all(promises);
+      });
+  };
+
   client.scanAll = function scanAllRecords(params, items = []) {
     return client.scanAsync(params)
       .then((results) => {

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -69,9 +69,9 @@ function createClient(config) {
    * Works like queryAll but on each page of the query a callback is invoked.  Its expected that the callback returns a promise.
    * This function will resolve when all paged callback promises(param pagePromise) resolve.
    *
-   * @param params {Object} - Original query params
-   * @param pagePromise {Function} - A function that returns a promise
-   * @param promises {Array} - not intended to be passed, this collects promises for paging resolution
+   * @param params {Object} - Query Params for DynamoDB.DocumentClient.query
+   * @param pagePromise {Function} - A callback function that returns a promise
+   * @param promises {Array} - Not intended to be passed, this collects promises for paging resolution
    * @returns {*|PromiseLike<T>|Promise<T>}
    */
   client.queryAllPager = function queryAllRecordsPager(params, pagePromise, promises = []) {


### PR DESCRIPTION
Right now, specifically used for the salesforce sync, but we could definitely use this pattern in other places too