### PR TITLE
FAD-6457 adds configurable sns topic prefix

### DIFF
--- a/lib/sns.js
+++ b/lib/sns.js
@@ -4,12 +4,12 @@ const AWS = require('aws-sdk');
 const Promise = require('bluebird');
 const clientConfig = require('./client-config');
 
-module.exports = function({ account, arnSuffix = '', defaultSubject = '' }) {
+module.exports = function({ account, arnPrefix = 'sns-', arnSuffix = '', defaultSubject = '' }) {
   const SNS = new AWS.SNS(clientConfig);
   const publish = Promise.promisify(SNS.publish, { context: SNS });
 
   function constructARN(name) {
-    return `arn:aws:sns:${AWS.config.region}:${account}:sns-${name}${arnSuffix}`;
+    return `arn:aws:sns:${AWS.config.region}:${account}:${arnPrefix}${name}${arnSuffix}`;
   }
 
   return {

--- a/test/unit/lib/sns.spec.js
+++ b/test/unit/lib/sns.spec.js
@@ -113,6 +113,20 @@ describe('SNS Utilities', function() {
         });
     });
 
+    it('should allow arnPrefix to be overriden', function() {
+      testConfig.arnPrefix = 'sneeze-'; // the proper way to pronounce SNS. this is canon.
+      snsInstance = sns(testConfig);
+
+      return snsInstance.publish({ message, topicName: 'topic', subject: 'Arya' })
+        .then(() => {
+          expect(snsMock.publish).to.have.been.calledWith({
+            Message: message,
+            Subject: 'Arya',
+            TopicArn: 'arn:aws:sns:Winterfel:Stark:sneeze-topic-ending'
+          });
+        });
+    });
+
     it('should stringify non-string messages', function() {
       const message = { jon: 'snow' };
 


### PR DESCRIPTION
I want to use our AWS wrapper to push onto the internal event hose, but they follow different naming conventions than we do. For example, the firehose topic names aren't prefixed with `sns-`. This PR makes the prefix configurable, defaulting to `sns-` which is our standard.