### PR TITLE
stops defaulting sns subject to the empty string

### DIFF
--- a/lib/sns.js
+++ b/lib/sns.js
@@ -4,7 +4,7 @@ const AWS = require('aws-sdk');
 const Promise = require('bluebird');
 const clientConfig = require('./client-config');
 
-module.exports = function({ account, arnPrefix = 'sns-', arnSuffix = '', defaultSubject = '' }) {
+module.exports = function({ account, arnPrefix = 'sns-', arnSuffix = '', defaultSubject }) {
   const SNS = new AWS.SNS(clientConfig);
   const publish = Promise.promisify(SNS.publish, { context: SNS });
 

--- a/test/unit/lib/sns.spec.js
+++ b/test/unit/lib/sns.spec.js
@@ -66,7 +66,7 @@ describe('SNS Utilities', function() {
         .then(() => {
           expect(snsMock.publish).to.have.been.calledWith({
             Message: message,
-            Subject: '',
+            Subject: undefined,
             TopicArn: arn
           });
         });


### PR DESCRIPTION
SNS does not like the empty string as a subject and publishing will fail. `undefined` is fine though. So just don't default the Subject of a message to anything.