### PR TITLE
AC-10 makes region configurable for sns topics

### DIFF
--- a/lib/sns.js
+++ b/lib/sns.js
@@ -4,12 +4,12 @@ const AWS = require('aws-sdk');
 const Promise = require('bluebird');
 const clientConfig = require('./client-config');
 
-module.exports = function({ account, arnPrefix = 'sns-', arnSuffix = '', defaultSubject }) {
+module.exports = function({ account, arnPrefix = 'sns-', arnSuffix = '', defaultSubject, region = AWS.config.region }) {
   const SNS = new AWS.SNS(clientConfig);
   const publish = Promise.promisify(SNS.publish, { context: SNS });
 
   function constructARN(name) {
-    return `arn:aws:sns:${AWS.config.region}:${account}:${arnPrefix}${name}${arnSuffix}`;
+    return `arn:aws:sns:${region}:${account}:${arnPrefix}${name}${arnSuffix}`;
   }
 
   return {

--- a/test/unit/lib/sns.spec.js
+++ b/test/unit/lib/sns.spec.js
@@ -127,6 +127,21 @@ describe('SNS Utilities', function() {
         });
     });
 
+    it('should allow region to be overridden', function() {
+      testConfig.region = 'kings-landing';
+
+      snsInstance = sns(testConfig);
+
+      return snsInstance.publish({ message, topicName: 'topic', subject: 'Arya' })
+        .then(() => {
+          expect(snsMock.publish).to.have.been.calledWith({
+            Message: message,
+            Subject: 'Arya',
+            TopicArn: 'arn:aws:sns:kings-landing:Stark:sns-topic-ending'
+          });
+        });
+    });
+
     it('should stringify non-string messages', function() {
       const message = { jon: 'snow' };
 


### PR DESCRIPTION
There is no IEH in EU, instead we use the IEH in us-west-2. We cannot rely on the EU AWS config in our APIs so we need region to be configurable.