### PR TITLE
Possible path forward for handling aws new promise-busting names

### DIFF
--- a/lib/cloudsearch.js
+++ b/lib/cloudsearch.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const Promise = require('bluebird');
 const clientConfig = require('./client-config');
 const _ = require('lodash');
+const promisify = require('./utils').promisify;
 
 function createClient(config = {}) {
   config = _.merge(_.cloneDeep(clientConfig), config);
   const client = new AWS.CloudSearchDomain(config);
-  Promise.promisifyAll(client);
+  promisify(client);
 
   return client;
 }

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const Promise = require('bluebird');
 const AWS = require('aws-sdk');
 const helpers = require('./dynamo-helpers');
 const _ = require('lodash');
 const clientConfig = require('./client-config');
 const https = require('https');
+const promisify = require('./utils').promisify;
 
 /**
  * create an http agent for the given configuration
@@ -66,7 +66,7 @@ function createClient(config) {
 
   const client = new AWS.DynamoDB.DocumentClient(config);
   client.consistentReads = config.consistentReads || false;
-  Promise.promisifyAll(client);
+  promisify(client);
 
   // patch read methods to use consistent read if specified
   _.forEach(['queryAsync', 'getAsync', 'scanAsync'], function(fname) {

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -10,6 +10,7 @@ const zlib = require('zlib');
 const compress = util.promisify(zlib.gzip);
 const decompress = util.promisify(zlib.gunzip);
 const computeMessageSize = require('./utils').computeMessageSize;
+const promisify = require('./utils').promisify;
 
 // 256kb => b
 const MAX_MSG_SIZE = 262144;
@@ -26,8 +27,8 @@ module.exports = ({ account, queuePrefix = '', queueSuffix = '', defaultVisibili
   const SQS = new AWS.SQS(clientConfig);
   const S3 = new AWS.S3(clientConfig);
 
-  Promise.promisifyAll(SQS);
-  Promise.promisifyAll(S3);
+  promisify(SQS);
+  promisify(S3);
 
   function getQueueURL(name) {
     return `https://sqs.${AWS.config.region}.amazonaws.com/${account}/${queuePrefix}${name}${queueSuffix}`;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Promise = require('bluebird');
 const _ = require('lodash');
 const byteLength = require('buffer').Buffer.byteLength;
 const utils = module.exports;
@@ -42,4 +43,10 @@ utils.computeMessageSize = function computeMessageSize(body, attrs) {
   }, 0);
 
   return byteLength(Buffer.from(body).toString('base64')) + attrsSize;
+};
+
+utils.promisify = function promisify(obj) {
+  Promise.promisifyAll(obj, {
+    filter: (name) => name.indexOf('Async') === -1
+  });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,26 +126,25 @@
       "integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k="
     },
     "aws-sdk": {
-      "version": "2.90.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.90.0.tgz",
-      "integrity": "sha1-ff5cXOLyt9M+9CZpJYb31TmRnqA=",
+      "version": "2.327.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.327.0.tgz",
+      "integrity": "sha512-qmDXPR7i2NhK2Gsvfh9TIkHyx6P1YGQ+3n08EIJrQ+Lgl8mS63Xg5AuMtOXszdRivjh3G6LTJe6HXmpsebkL1w==",
       "requires": {
         "buffer": "4.9.1",
-        "crypto-browserify": "1.0.9",
-        "events": "^1.1.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.0.1",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
+        "uuid": "3.1.0",
+        "xml2js": "0.4.19"
       },
       "dependencies": {
         "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
@@ -167,9 +166,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "bluebird": {
       "version": "3.5.0",
@@ -383,11 +382,6 @@
           }
         }
       }
-    },
-    "crypto-browserify": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
-      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -3847,21 +3841,18 @@
       }
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "^4.0.0"
-      }
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "aws-sdk": "^2.73.0",
+    "aws-sdk": "^2.327.0",
     "bluebird": "^3.5.0",
     "lodash": "^4.17.4",
     "proxy-agent": "^2.0.0",

--- a/test/unit/lib/utils.spec.js
+++ b/test/unit/lib/utils.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chai = require('chai');
+const sinon = require('sinon');
 const expect = chai.expect;
 const utils = require('../../../lib/utils');
 
@@ -17,5 +18,18 @@ describe('AWS Library utilities', function() {
 
   testCases.forEach(function([testCase, body, attrs, expectedValue]) {
     it(testCase, () => expect(utils.computeMessageSize(body, attrs)).to.equal(expectedValue));
+  });
+
+  it('should allow for promisifying an object with async methods', function() {
+    const badAmazon = {
+      onAsyncWhyAmazon: sinon.stub().resolves(true),
+      callbackExample: function(cb) { return cb(null, true); }
+    };
+
+    utils.promisify(badAmazon);
+    return badAmazon.onAsyncWhyAmazon()
+      .then((ret) => expect(ret).to.be.true)
+      .then(() => badAmazon.callbackExampleAsync())
+      .then((ret) => expect(ret).to.be.true);
   });
 });


### PR DESCRIPTION
This is the underlying issue:

https://github.com/aws/aws-sdk-js/commit/fe88308a8699b39aef06492c898b265a3a24251f#diff-cca1065697cbb567e3320496b1f7448fR43

I thought I was going to have to do something way more invasive (hence the `v2` branch name), but we could probably publish this as a minor version, it's not really breaking anything.  Though i did upgrade to latest aws package so 🤷‍♂️ 