### PR TITLE
Tr 2037 Compute msg size after compress

### DIFF
--- a/lib/sqs/index.js
+++ b/lib/sqs/index.js
@@ -11,10 +11,14 @@ const compress = util.promisify(zlib.gzip);
 const decompress = util.promisify(zlib.gunzip);
 const { computeMessageSize, promisify, setHttpAgent } = require('../utils');
 
-// 256kb => b
+// 256kb => b: (256kb * 1024 bytes =  262144)
 const MAX_MSG_SIZE = 262144;
-//64kb => bytes
-const MAX_COMPRESS_MSG_SIZE = 65536;
+/*
+ * Max size of message that does not need to be compressed as it can be sent via 1 SQS Operation
+ *  64kb => b: (64kb * 1024 bytes = 65536 bytes - 50 bytes = 65486)
+ *  -50 bytes to compensate for size increase after compressing with no compression level
+*/
+const MAX_COMPRESS_MSG_SIZE = 65486;
 
 /**
  * Convenience class for wrapping sqs methods with promises
@@ -240,15 +244,13 @@ module.exports = ({
       let key = false
         ,level = zlib.constants.Z_DEFAULT_COMPRESSION;
 
-      const messageSize = computeMessageSize(payload, attrs);
-
-      if (messageSize < MAX_COMPRESS_MSG_SIZE) {
+      if (computeMessageSize(payload, attrs) < MAX_COMPRESS_MSG_SIZE) {
         level = zlib.constants.Z_NO_COMPRESSION; // no compression
       }
 
       return compress(payload, { level })
         .then((payload) => {
-          if (messageSize > MAX_MSG_SIZE) {
+          if (computeMessageSize(payload, attrs) > MAX_MSG_SIZE) {
             key = `/${Math.floor(Math.random() * shards)}/${uuid()}.json.gz`;
 
             return S3.uploadAsync({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/aws",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "name": "@sparkpost/aws",
   "description": "Thin wrappers around the aws-sdk libraries we use.",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "main": "index.js",
   "devDependencies": {
     "auditmated": "^0.1.2",

--- a/test/unit/lib/sqs.spec.js
+++ b/test/unit/lib/sqs.spec.js
@@ -414,7 +414,7 @@ describe('SQS Utilities', function() {
         });
     });
 
-    it('should send as sqs messages when payload size is >=256kb & compresses to <=256kb', function() {
+    it('should send as sqs message when payload size is >=256kb & compresses to <=256kb', function() {
       // Expecting payload size of 293348 bytes to compress down to ~198416 bytes
       const expected_compress_level = zlib.constants.Z_DEFAULT_COMPRESSION;
       let payload;
@@ -456,10 +456,10 @@ describe('SQS Utilities', function() {
         });
     });
 
-    it('should send as sqs messages and not compress if compressed payload <=64kb', function() {
+    it('should send as sqs message and compress if payload barely >(64kb - 50b)', function() {
       // Payload of ~65488 bytes should get compressed to ~112 bytes
       const expected_compress_level = zlib.constants.Z_DEFAULT_COMPRESSION;
-      const payload = _.repeat('a', 49115); //repeat to ~65488 bytes ()> 65486 limit)
+      const payload = _.repeat('a', 49115); //repeat to ~65488 bytes (> 65486 limit)
 
       sinon.stub(Math, 'random');
       Math.random.returns(0.5);

--- a/test/unit/lib/sqs.spec.js
+++ b/test/unit/lib/sqs.spec.js
@@ -413,6 +413,84 @@ describe('SQS Utilities', function() {
           );
         });
     });
+
+    it('should send as sqs messages when payload size is >=256kb & compresses to <=256kb', function() {
+      // Expecting payload size of 293348 bytes to compress down to ~198416 bytes
+      const expected_compress_level = zlib.constants.Z_DEFAULT_COMPRESSION;
+      let payload;
+
+      for (let index = 0; index < 220000; index++) {
+        payload += Math.random()
+          .toString(36)
+          .substr(2, 1);
+      } // Payload size = 293348
+
+      sinon.stub(Math, 'random');
+      Math.random.returns(0.5);
+
+      return sqsInstance
+        .extendedSend({
+          queueName: 'queue',
+          s3Bucket: 'test',
+          payload,
+          attrs: {
+            foo: 'bar',
+            EXTENDED_S3_KEY: 'imakey',
+            EXTENDED_S3_BUCKET: 'imabucket'
+          }
+        })
+        .then((res) => {
+          expect(res).to.deep.equal({
+            res: result,
+            extended: false,
+            key: false
+          }); // Expecting to send via SQS only
+          expect(sqsMock.sendMessage.callCount).to.equal(1);
+          expect(sqsMock.sendMessage.args[0][0]).to.deep.equal({
+            MessageBody: compress(payload, {
+              level: expected_compress_level
+            }).toString('base64'),
+            QueueUrl: queueUrl,
+            MessageAttributes: { foo: 'bar' }
+          }); // Expecting to be compressed (>64kb)
+        });
+    });
+
+    it('should send as sqs messages and not compress if compressed payload <=64kb', function() {
+      // Payload of ~65488 bytes should get compressed to ~112 bytes
+      const expected_compress_level = zlib.constants.Z_DEFAULT_COMPRESSION;
+      const payload = _.repeat('a', 49115); //repeat to ~65488 bytes ()> 65486 limit)
+
+      sinon.stub(Math, 'random');
+      Math.random.returns(0.5);
+
+      return sqsInstance
+        .extendedSend({
+          queueName: 'queue',
+          s3Bucket: 'test',
+          payload,
+          attrs: {
+            foo: 'bar',
+            EXTENDED_S3_KEY: 'imakey',
+            EXTENDED_S3_BUCKET: 'imabucket'
+          }
+        })
+        .then((res) => {
+          expect(res).to.deep.equal({
+            res: result,
+            extended: false,
+            key: false
+          }); // Expecting to send via SQS only
+          expect(sqsMock.sendMessage.callCount).to.equal(1);
+          expect(sqsMock.sendMessage.args[0][0]).to.deep.equal({
+            MessageBody: compress(payload, {
+              level: expected_compress_level
+            }).toString('base64'),
+            QueueUrl: queueUrl,
+            MessageAttributes: { foo: 'bar' }
+          }); // Expecting to be compressed (>64kb - 50bytes)
+        });
+    });
   });
 
   describe('extendedRetrieve', function() {


### PR DESCRIPTION
* Compute msg size after compress in extendedSend().
* Fix minor bug where need to compensate for payload size increase after compressing with no compression (~50bytes difference).