### PR TITLE
feat: track s3 upload attempts, retry for any 5xx error

### DIFF
--- a/lib/sqs/index.js
+++ b/lib/sqs/index.js
@@ -280,7 +280,7 @@ module.exports = ({
                   // Use a random shard as path prefix by default for backwards compatibility,
                   // however, S3 throttles during high throughput events are more likely.
                   // `uuidPrefix` allows ultra high throughput by avoiding a fixed number of shards.
-                  // To reduce the likelihood of running into S3 capacity issues (slow down/503 errors),
+                  // To reduce the likelihood of running into S3 capacity issues (5xx errors),
                   // it also generates a new UUID on each retry attempt.
                   const prefix = uuidPrefix
                     ? uuid()
@@ -297,8 +297,8 @@ module.exports = ({
                   key = s3Key;
                   break;
                 } catch (err) {
-                  const isSlowDown = err.code === 'SlowDown' || err.statusCode === 503;
-                  const shouldRetry = uuidPrefix && isSlowDown && s3Attempt < maxS3Attempts - 1;
+                  const is5xxError = err.statusCode >= 500 && err.statusCode < 600;
+                  const shouldRetry = uuidPrefix && is5xxError && s3Attempt < maxS3Attempts - 1;
 
                   if (!shouldRetry) {
                     throw err;


### PR DESCRIPTION
**[TASK-114968](https://app.bird.com/workspaces/e9d00796-afb3-458e-ad85-64a1bdefe3aa/initiatives/tasks/TASK-114968) Add retry for S3 "SlowDown" errors in Front door**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track S3 upload attempts and retry S3 uploads on any 5xx in `extendedSend`, adding `s3UploadAttempts` and expanding tests to cover new retry/attempt behaviors.
> 
> - **SQS library (`lib/sqs/index.js`)**:
>   - `extendedSend`: retry S3 uploads on any 5xx when `uuidPrefix=true`, generating a new UUID per attempt; refactor retry loop to track attempts; add `s3UploadAttempts` to the return payload; update comments/messages accordingly.
> - **Tests (`test/unit/lib/sqs.spec.js`)**:
>   - Update expectations to include `s3UploadAttempts` (0 for SQS-only, 1+ for S3 uploads).
>   - Add cases for 500/502/503/504 retries, max-attempts behavior, non-5xx no-retry, no-retry when `uuidPrefix=false`, unique-UUID per retry, and attempt tracking.
>   - Adjust existing UUID-prefix and shard-prefix tests to assert attempt counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f512b65bbd561c9671828bcc06e3a7e09c347af0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->