### PR TITLE
fix: support http:// endpoints in DynamoDB HTTP agent

### DIFF
--- a/lib/dynamo/index.js
+++ b/lib/dynamo/index.js
@@ -4,8 +4,19 @@ const AWS = require('aws-sdk');
 const helpers = require('./dynamo-helpers');
 const _ = require('lodash');
 const clientConfig = require('../client-config');
+const http = require('http');
 const https = require('https');
 const promisify = require('../utils').promisify;
+
+function isHttpEndpoint(endpoint) {
+  if (!endpoint) {
+    return false;
+  }
+  if (typeof endpoint === 'string') {
+    return endpoint.startsWith('http://');
+  }
+  return endpoint.protocol === 'http:';
+}
 
 /**
  * create an http agent for the given configuration
@@ -19,12 +30,13 @@ function setupHTTPAgent(config) {
   config.httpOptions = _.merge(config.httpOptions, {});
   // TT
   if (bypassProxy === true && useKeepalives === true) {
-    // create a new agent w/ keepalive configuration
-    config.httpOptions.agent = new https.Agent({
-      keepAlive: true,
-      rejectUnauthorized: true,
-      maxSockets: 50
-    });
+    const isHttp = isHttpEndpoint(config.endpoint);
+    const AgentClass = isHttp ? http.Agent : https.Agent;
+    const agentOptions = { keepAlive: true, maxSockets: 50 };
+    if (!isHttp) {
+      agentOptions.rejectUnauthorized = true;
+    }
+    config.httpOptions.agent = new AgentClass(agentOptions);
   }
   // FF
   if (bypassProxy === false && useKeepalives === false) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,9 +1126,10 @@
       ]
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1154,9 +1155,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2658,10 +2659,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -4244,9 +4246,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -4731,9 +4734,9 @@
       "dev": true
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5456,9 +5459,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5511,33 +5514,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-eslint": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-15.0.1.tgz",
-      "integrity": "sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/eslint": "^8.4.2",
-        "@types/prettier": "^2.6.0",
-        "@typescript-eslint/parser": "^5.10.0",
-        "common-tags": "^1.4.0",
-        "dlv": "^1.1.0",
-        "eslint": "^8.7.0",
-        "indent-string": "^4.0.0",
-        "lodash.merge": "^4.6.0",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "prettier": "^2.5.1",
-        "pretty-format": "^23.0.1",
-        "require-relative": "^0.8.7",
-        "typescript": "^4.5.4",
-        "vue-eslint-parser": "^8.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/prettier-eslint-cli": {
@@ -6835,10 +6811,11 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 6"
       }
@@ -7759,9 +7736,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -7781,9 +7758,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -8848,9 +8825,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "for-each": {
@@ -9955,9 +9932,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -10317,9 +10294,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -10861,9 +10838,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
     "pify": {
@@ -10895,30 +10872,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
-    },
-    "prettier-eslint": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-15.0.1.tgz",
-      "integrity": "sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/eslint": "^8.4.2",
-        "@types/prettier": "^2.6.0",
-        "@typescript-eslint/parser": "^5.10.0",
-        "common-tags": "^1.4.0",
-        "dlv": "^1.1.0",
-        "eslint": "^8.7.0",
-        "indent-string": "^4.0.0",
-        "lodash.merge": "^4.6.0",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "prettier": "^2.5.1",
-        "pretty-format": "^23.0.1",
-        "require-relative": "^0.8.7",
-        "typescript": "^4.5.4",
-        "vue-eslint-parser": "^8.0.1"
-      }
     },
     "prettier-eslint-cli": {
       "version": "7.1.0",
@@ -11867,9 +11820,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true
     },
     "yargs": {

--- a/test/unit/lib/dynamo.spec.js
+++ b/test/unit/lib/dynamo.spec.js
@@ -1,0 +1,85 @@
+/* eslint id-length: "off" */
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const http = require('http');
+const https = require('https');
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+
+chai.use(require('sinon-chai'));
+
+describe('DynamoDB', function() {
+  let DynamoDB, documentClientStub;
+
+  beforeEach(function() {
+    documentClientStub = sinon.stub();
+    DynamoDB = proxyquire('../../../lib/dynamo', {
+      'aws-sdk': {
+        DynamoDB: {
+          DocumentClient: documentClientStub
+        }
+      },
+      '../client-config': {}
+    });
+  });
+
+  describe('setupHTTPAgent', function() {
+    it('should use https.Agent by default (no endpoint)', function() {
+      new DynamoDB({});
+      const config = documentClientStub.firstCall.args[0];
+      expect(config.httpOptions.agent).to.be.an.instanceOf(https.Agent);
+      expect(config.httpOptions.agent.options.rejectUnauthorized).to.equal(
+        true
+      );
+    });
+
+    it('should use https.Agent when endpoint is https://', function() {
+      new DynamoDB({ endpoint: 'https://dynamodb.us-west-2.amazonaws.com' });
+      const config = documentClientStub.firstCall.args[0];
+      expect(config.httpOptions.agent).to.be.an.instanceOf(https.Agent);
+    });
+
+    it('should use http.Agent when endpoint is http://', function() {
+      new DynamoDB({ endpoint: 'http://localhost:8000' });
+      const config = documentClientStub.firstCall.args[0];
+      const agent = config.httpOptions.agent;
+      expect(agent).to.be.an.instanceOf(http.Agent);
+      expect(agent).to.not.be.an.instanceOf(https.Agent);
+      expect(agent.keepAlive).to.equal(true);
+      expect(agent.maxSockets).to.equal(50);
+    });
+
+    it('should use http.Agent when endpoint is an object with http: protocol', function() {
+      new DynamoDB({ endpoint: { protocol: 'http:' } });
+      const config = documentClientStub.firstCall.args[0];
+      expect(config.httpOptions.agent).to.be.an.instanceOf(http.Agent);
+      expect(config.httpOptions.agent).to.not.be.an.instanceOf(https.Agent);
+    });
+
+    it('should not set rejectUnauthorized for http.Agent', function() {
+      new DynamoDB({ endpoint: 'http://localhost:8000' });
+      const config = documentClientStub.firstCall.args[0];
+      expect(config.httpOptions.agent.options.rejectUnauthorized).to.be
+        .undefined;
+    });
+
+    it('should not create an agent when bypassProxy=false and useKeepalives=false', function() {
+      new DynamoDB({ bypassProxy: false, useKeepalives: false });
+      const config = documentClientStub.firstCall.args[0];
+      expect(config.httpOptions.agent).to.be.undefined;
+    });
+
+    it('should strip bypassProxy and useKeepalives from config passed to DocumentClient', function() {
+      new DynamoDB({
+        bypassProxy: true,
+        useKeepalives: true,
+        endpoint: 'http://localhost:8000'
+      });
+      const config = documentClientStub.firstCall.args[0];
+      expect(config).to.not.have.property('bypassProxy');
+      expect(config).to.not.have.property('useKeepalives');
+    });
+  });
+});


### PR DESCRIPTION
## Why

Same issue as #87 for SQS — the DynamoDB module's `setupHTTPAgent` always creates an `https.Agent`, which attempts a TLS handshake on plain HTTP ports (e.g. DynamoDB Local at `http://localhost:8000`) and fails with `Protocol "http:" not supported`.

## Summary
- **`setupHTTPAgent`** — when the endpoint uses `http://`, create an `http.Agent` instead of `https.Agent`, matching the fix in `utils.setHttpAgent` from #87.
- Handles both string endpoints (`"http://localhost:8000"`) and parsed endpoint objects (`{ protocol: 'http:' }`).
- Added unit tests covering https (default), https:// URL, http:// URL, endpoint object, and config stripping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested change limited to HTTP agent selection for DynamoDB endpoints plus routine `package-lock.json` dependency updates.
> 
> **Overview**
> Fixes `lib/dynamo/setupHTTPAgent` to **choose `http.Agent` for `http://` DynamoDB endpoints** (string or `{ protocol: 'http:' }`) while keeping `https.Agent` (with `rejectUnauthorized`) for HTTPS/default cases.
> 
> Adds unit tests asserting agent selection, keepalive options, and that `bypassProxy`/`useKeepalives` are not forwarded to `DocumentClient`. Also refreshes `package-lock.json` with several dependency version bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eee3d3b257ed2d631e733b4e88b969ee548fd3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->